### PR TITLE
Custom providers

### DIFF
--- a/src/Kalley/LaravelOauthClient/AbstractOAuthClient.php
+++ b/src/Kalley/LaravelOauthClient/AbstractOAuthClient.php
@@ -11,24 +11,21 @@ abstract class AbstractOAuthClient {
 
   public static function factory($providerName, $config) {
     $providerName = strtolower($providerName);
-    switch ( $providerName ) {
-      case 'twitter':
-      case 'bitbucket':
-      case 'tumblr':
-        return new OAuth1Client($providerName, $config);
-      default:
-        return new OAuth2Client($providerName, $config);
+    if (array_key_exists('identifier', $config)) {
+      return new OAuth1Client($providerName, $config);
+    } else {
+      return new OAuth2Client($providerName, $config);
     }
   }
 
   public function __construct($providerName, $config) {
     $this->providerName = strtolower($providerName);
-    $providerClass = $this->namespace . (isset($this->mapped[$this->providerName]) ? $this->mapped[$this->providerName] : $this->providerName);
+    $providerClass = (isset($this->mapped[$this->providerName]) ? $this->namespace . $this->mapped[$this->providerName] : (array_key_exists('providerClass', $config)) ? $config['providerClass'] : $this->providerName);
     $this->provider = new $providerClass($config);
   }
 
   abstract public function getAccessToken($code);
-  
+
   public function setAccessToken(AccessToken $token) {
     $this->token = $token;
   }

--- a/src/Kalley/LaravelOauthClient/Facades/BitbucketFacade.php
+++ b/src/Kalley/LaravelOauthClient/Facades/BitbucketFacade.php
@@ -9,6 +9,6 @@ class BitbucketFacade extends Facade {
    * @codeCoverageIgnore
    */
   protected static function getFacadeAccessor() {
-    return 'oauth-client.butbucket';
+    return 'oauth-client.bitbucket';
   }
 }

--- a/src/config/oauth-client.php
+++ b/src/config/oauth-client.php
@@ -40,12 +40,14 @@ return [
   |   'oauth1server' => [
   |     'identifier' => 'your-identifier',
   |     'secret' => 'your-secret',
-  |     'callback_uri' => 'http://your-callback-uri/'
+  |     'callback_uri' => 'http://your-callback-uri/',
+  |     'providerClass' => '{Namespace}\{Class}' // this is required when using a custom provider
   |   ],
   |   'oauth2provider' => [
   |     'clientId'  =>  'XXXXXXXX',
   |     'clientSecret'  =>  'XXXXXXXX',
-  |     'redirectUri'   =>  'https://your-registered-redirect-uri/'
+  |     'redirectUri'   =>  'https://your-registered-redirect-uri/',
+  |     'providerClass' => '{Namespace}\{Class}' // this is required when using a custom provider
   |   ]
   | ]
   |


### PR DESCRIPTION
This change allows users to use custom oauth providers that are not built in to the package by default.

Custom provider classes can be defined in the config file using the following syntax:

```
'custom-name' => [
...,
'providerClass' => '{Namespace}\{Class}'
]
```